### PR TITLE
Add the gulp-sass package and compile scss to css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+public/

--- a/README.md
+++ b/README.md
@@ -177,6 +177,35 @@ Default task
 Finished 'default'
 ```
 
+#### Install gulp-sass
+
+* `npm install gulp-sass --save-dev`
+
+#### Add scss compilation to the project
+
+* Add an `application.scss` file to `assets/scss`
+
+#### Add a Gulp `styles` task to compile scss to css
+
+In Gulpfile.js
+
+```
+// Compile Sass to CSS
+gulp.task('styles', function () {
+  gulp.src(paths.assetsScss + '**/*.scss')
+    .pipe(sass().on('error', sass.logError))
+    .pipe(gulp.dest(paths.publicCss))
+})
+```
+
+#### Add a config file for paths
+
+Add a config file in /config/paths.json and add paths for assetsScss and publicCss.
+
+### Add the /public folder to .gitgnore
+
+The app compiles assets to /public, these don't need to be in version control.
+
 
 
 

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -1,0 +1,2 @@
+// Add a path for image assets using the url-helpers function
+$path: '/public/images/';

--- a/config/paths.json
+++ b/config/paths.json
@@ -1,0 +1,11 @@
+{
+"config": "config/",
+"assetsImg": "assets/images/",
+"assetsJs": "assets/js/",
+"assetsScss": "assets/scss/",
+"views": "views/",
+"public": "public/",
+"publicImg": "public/images/",
+"publicCss": "public/css/",
+"publicJs": "public/js/"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,15 +2,23 @@
 
 var paths = require('./config/paths.json')
 var gulp = require('gulp')
+var gutil = require('gulp-util')
 var sass = require('gulp-sass')
+var rename = require('gulp-rename')
 
 gulp.task('default', function () {
   console.log('Default task')
 })
 
-// Compile Sass to CSS
+// Styles build task ---------------------
+// Compiles CSS from Sass
+// Output both a minified and non-minified version into /public/css.
+// ---------------------------------------
+
 gulp.task('styles', function () {
   gulp.src(paths.assetsScss + '**/*.scss')
     .pipe(sass().on('error', sass.logError))
+    .pipe(gulp.dest(paths.publicCss))
+    .pipe(rename({ suffix: '.min' }))
     .pipe(gulp.dest(paths.publicCss))
 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,16 @@
+'use strict'
+
+var paths = require('./config/paths.json')
 var gulp = require('gulp')
+var sass = require('gulp-sass')
 
 gulp.task('default', function () {
   console.log('Default task')
+})
+
+// Compile Sass to CSS
+gulp.task('styles', function () {
+  gulp.src(paths.assetsScss + '**/*.scss')
+    .pipe(sass().on('error', sass.logError))
+    .pipe(gulp.dest(paths.publicCss))
 })

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "gulp": "^3.9.1",
+    "gulp-rename": "^1.2.2",
     "gulp-sass": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "nunjucks": "^3.0.0"
   },
   "devDependencies": {
-    "gulp": "^3.9.1"
+    "gulp": "^3.9.1",
+    "gulp-sass": "^3.1.0"
   }
 }


### PR DESCRIPTION
- Add instructions for setup to the README
- Add gulp-sass as a dependency
- Add a gulp styles task to compile scss to css
- Add a config file for application paths
- Define the $path for image assets using the url-helpers function in
the scss files
- Add the /public folder to the gitignore file