### PR TITLE
Update app.js to include the path to components

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,9 +6,10 @@ var path = require('path')
 // Set the template engine to use nunjucks
 app.set('view engine', 'nunjucks')
 
-// Set the location of the template files
+// Set the location of the component and template files
 var appViews = [
   path.join(__dirname, 'views'),
+  path.join(__dirname, '/node_modules/govuk_frontend_alpha/components/'),
   path.join(__dirname, '/node_modules/govuk_frontend_alpha/templates/')
 ]
 


### PR DESCRIPTION
Without this, when following the node setup instructions - there is a
“template not found” error for the `components.njk` file.