### PR TITLE
Update the readme, ensure the "simple" setup path works

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,41 @@ It's a Node & ExpressJS app, with Nunjucks for templating.
   ```
 
 You'll be able to see the app running here: [localhost:3000](http://localhost:3000/)
+
+
+## Application setup
+
+Take a look in `server.js` to see how this app works.
+
+Static content is served from the public directory:
+
+```javascript
+app.use('/public', express.static(path.join(__dirname, '/public')))
+```
+
+## Using GOV.UK frontend
+
+### Default
+
+The compiled 'default stylesheet' expects images to be in the `images/toolkit` and `images/template` directories.
+
+For the default compiled stylesheet only - this application has been set to serve the govuk_frontend_alpha toolkit and template assets from the node_modules directory:
+
+In `server.js`:
+
+```javascript
+app.use('/images/toolkit', express.static(path.join(__dirname, '/node_modules/govuk_frontend_alpha/assets/images/toolkit/')))
+app.use('/images/template', express.static(path.join(__dirname, '/node_modules/govuk_frontend_alpha/assets/images/template/')))
+```
+
+### Custom - replacing the default stylesheet
+
+If the application compiles the govuk_frontend_alpha scss files and overrides the `stylesheet` block, the above config can be removed.
+
+To serve the govuk_frontend_alpha assets from the node_modules directory, in `server.js` use:
+
+```javascript
+app.use('/public', express.static(path.join(__dirname, '/node_modules/govuk_frontend_alpha/assets/')))
+```
+
+To ensure the path to the image assets is correct, `$path` must be defined at the top of `application.scss`, find this in `assets/scss/application.scss`.

--- a/README.md
+++ b/README.md
@@ -11,19 +11,11 @@ It's a Node & ExpressJS app, with Nunjucks for templating.
 2. Next, install the dependencies:
 
   ```sh
-  $ yarn
-  ```
-  or
-  ```sh
   $ npm install
   ```
 
 3. To run the web server:
 
-  ```sh
-  $ yarn start
-  ```
-  or
   ```sh
   $ npm start
   ```

--- a/server.js
+++ b/server.js
@@ -25,6 +25,8 @@ nunjucks.configure(appViews, {
 app.use('/public', express.static(path.join(__dirname, '/public')))
 // Serve the govuk_frontend_alpha assets from the node_modules directory
 app.use('/public', express.static(path.join(__dirname, '/node_modules/govuk_frontend_alpha/assets/')))
+// For the default compiled stylesheet only - serve the govuk_frontend_alpha toolkit and template assets from the node_modules directory
+app.use('/images/toolkit', express.static(path.join(__dirname, '/node_modules/govuk_frontend_alpha/assets/images/toolkit/')))
 app.use('/images/template', express.static(path.join(__dirname, '/node_modules/govuk_frontend_alpha/assets/images/template/')))
 
 // Send assetPath to all views


### PR DESCRIPTION
Update the readme:
* remove yarn, using npm install works as expected and shortens the installation steps.
* add detail for configuring this application

Amend server.js:
* ensure that if the default stylesheet is used, paths to image assets for the template and toolkit are not broken