### PR TITLE
Start on unique non-3000 port, to avoid conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It's a Node & ExpressJS app, with Nunjucks for templating.
   $ npm start
   ```
 
-You'll be able to see the app running here: [localhost:3000](http://localhost:3000/)
+You'll be able to see the app running here: [localhost:3005](http://localhost:3005/)
 
 
 ## Application setup

--- a/server.js
+++ b/server.js
@@ -42,5 +42,5 @@ app.get('/', function (req, res) {
 
 // Log when app is running
 app.listen(3005, function () {
-  console.log('Example app listening on port 3005!')
+  console.log('Listening on port 3005    url: http://localhost:3005')
 })

--- a/server.js
+++ b/server.js
@@ -41,6 +41,6 @@ app.get('/', function (req, res) {
 })
 
 // Log when app is running
-app.listen(3000, function () {
-  console.log('Example app listening on port 3000!')
+app.listen(3005, function () {
+  console.log('Example app listening on port 3005!')
 })


### PR DESCRIPTION
1. Avoids problems where govuk_frontend_alpha/Fractal is running on
   3000 by default, and starting this app conflicts. We should be able
   to run both apps side by side, on different ports by default.

2. This allows the use of pow to map different apps/ports to development
   domains. I've been finding keeping track of which localhost/port combo
   a particular app is running on, pinning to a unique default port helps
   and allows mapping a custom domain through pow, eg I have:

   govuk-frontend.dev => localhost:3000
   node-govuk-frontend.dev => localhost:3005

pow: http://pow.cx/manual.html