### PR TITLE
Add the layout template back, set the index to inherit from it

### DIFF
--- a/views/index.njk
+++ b/views/index.njk
@@ -1,3 +1,8 @@
+{% extends "layout.njk" %}
+
 {% block content %}
-  Hello world
+
+  <h1>Starter Node application</h1>
+  <p>Find this template in <code>app/views/index.njk</code></p>
+
 {% endblock %}

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -1,0 +1,2 @@
+{% block content %}
+{% endblock %}


### PR DESCRIPTION
Add a layout template, so that research can involve tasks which set a block that appears on mutiple pages, for example, a phase banner.

Also add “welcome to the starter node application” and the location of
the index template file - to match the starter Rails app.