### PR TITLE
Add GOV.UK Frontend Alpha

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -1,2 +1,4 @@
 // Add a path for image assets using the url-helpers function
 $path: '/public/images/';
+
+@import '../../node_modules/govuk_frontend_alpha/assets/scss/govuk-frontend';

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -1,4 +1,4 @@
 // Add a path for image assets using the url-helpers function
 $path: '/public/images/';
 
-@import '../../node_modules/govuk_frontend_alpha/assets/scss/govuk-frontend';
+@import 'govuk-frontend';

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,9 @@ gulp.task('clean', () => {
 
 gulp.task('styles', () => {
   return gulp.src(paths.assetsScss + '**/*.scss')
-    .pipe(sass().on('error', sass.logError))
+    .pipe(sass({
+      includePaths: ['node_modules/govuk_frontend_alpha/assets/scss/']
+    }).on('error', sass.logError))
     .pipe(gulp.dest(paths.publicCss))
     .pipe(rename({ suffix: '.min' }))
     .pipe(gulp.dest(paths.publicCss))

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "express": "^4.14.0",
     "nunjucks": "^3.0.0",
-    "standard": "^8.6.0"
+    "standard": "^8.6.0",
+    "govuk_frontend_alpha": "https://github.com/alphagov/govuk_frontend_alpha/releases/download/0.0.1-alpha/govuk_frontend_alpha-0.0.1-npm.tgz"
   },
   "devDependencies": {
     "del": "^2.2.2",

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -1,2 +1,4 @@
+{% extends "govuk_template.njk" %}
+
 {% block content %}
 {% endblock %}

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -1,6 +1,6 @@
 {% extends "govuk_template.njk" %}
 
-{% block head %}
+{% block stylesheet %}
   <link href="{{ asset_path }}stylesheets/application.css" media="screen" rel="stylesheet" />
 {% endblock %}
 

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -1,4 +1,8 @@
 {% extends "govuk_template.njk" %}
 
+{% block head %}
+  <link href="{{ asset_path }}stylesheets/application.css" media="screen" rel="stylesheet" />
+{% endblock %}
+
 {% block content %}
 {% endblock %}


### PR DESCRIPTION
This PR follows the documentation instructions from here: http://govuk-frontend-alpha.herokuapp.com/docs/using-with-node to add GOV.UK Frontend alpha as a dependency to this starter kit.



